### PR TITLE
Add token cost display and anti-hallucination safeguards

### DIFF
--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -3,6 +3,8 @@ export interface Thread {
   title: string;
   user_id: string | null;
   is_public: boolean;
+  input_tokens: number | null;
+  output_tokens: number | null;
   created_at: string;
   updated_at: string;
 }

--- a/supabase/migrations/005_add_token_tracking.sql
+++ b/supabase/migrations/005_add_token_tracking.sql
@@ -1,0 +1,3 @@
+-- Add token tracking columns to threads
+alter table threads add column if not exists input_tokens bigint default 0;
+alter table threads add column if not exists output_tokens bigint default 0;


### PR DESCRIPTION
## Summary
- Track and display token costs in chat header (shows running total for each conversation)
- Add critical anti-hallucination safeguards in system prompt - agent must always use API to get IDs
- Auto-generate chat titles in sentence case
- Add database migration for token tracking columns

## Test plan
- [ ] Start a new chat, send a message, verify cost appears after response
- [ ] Verify chat titles are generated in sentence case
- [ ] Test agent doesn't hallucinate IDs (should use API for all lookups)