### PR TITLE
Add meta-tool pattern to reduce tool token usage

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -5,11 +5,16 @@ export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
   const next = searchParams.get("next") ?? "/";
+  const type = searchParams.get("type");
 
   if (code) {
     const supabase = await createClient();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
+      // If this is a password recovery flow, redirect to update password page
+      if (type === "recovery" || next === "/login") {
+        return NextResponse.redirect(`${origin}/login?reset=true`);
+      }
       return NextResponse.redirect(`${origin}${next}`);
     }
   }


### PR DESCRIPTION
Instead of passing full tool definitions (100-300+ tokens each) to Claude on every turn, pass minimal stubs (~20-30 tokens) with just name and endpoint. Agent calls `get_tool_help` to fetch full docs before using a tool for the first time.

Saves 4-15k input tokens per turn with ~50 tools. Tradeoff is an extra round-trip the first time a tool is used, but the prompt tells Claude to batch multiple `get_tool_help` calls together.