### PR TITLE
Support artifacts with npm dependencies and bun builds

### DIFF
--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -10,6 +10,7 @@ interface AgentRequest {
   question: string;
   history: { role: string; content: string }[];
   threadId: string;
+  model?: string;
 }
 
 export async function POST(request: NextRequest) {
@@ -37,6 +38,7 @@ export async function POST(request: NextRequest) {
               thread_id: body.threadId,
               api_base_url: API_BASE_URL,
               history: body.history,
+              model: body.model || "claude-sonnet-4-5",
             }),
           }
         );

--- a/src/app/api/agent/spawn/route.ts
+++ b/src/app/api/agent/spawn/route.ts
@@ -8,6 +8,7 @@ interface SpawnRequest {
   question: string;
   history: { role: string; content: string }[];
   threadId: string;
+  model?: string;
 }
 
 export const maxDuration = 300; // Allow up to 5 minutes
@@ -33,6 +34,7 @@ export async function POST(request: NextRequest) {
           api_base_url: API_BASE_URL,
           history: body.history,
           user_id: user?.id,
+          model: body.model || "claude-sonnet-4-5",
         }),
       }
     );

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -265,6 +265,7 @@ function ToolCard({ step }: { step: ParsedStep }) {
 
 function ArtifactCard({ artifact }: { artifact: Artifact }) {
   const [isExpanded, setIsExpanded] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
   const artifactUrl = `https://nikhilwoodruff--policyengine-chat-agent-serve-artifact.modal.run?id=${artifact.id}`;
 
   return (
@@ -278,6 +279,9 @@ function ArtifactCard({ artifact }: { artifact: Artifact }) {
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7m0 10a2 2 0 002 2h2a2 2 0 002-2V7a2 2 0 00-2-2h-2a2 2 0 00-2 2" />
           </svg>
           <span className="text-sm font-medium text-[var(--color-text-primary)]">{artifact.title}</span>
+          {isLoading && isExpanded && (
+            <span className="text-xs text-[var(--color-text-muted)]">Building...</span>
+          )}
         </div>
         <div className="flex items-center gap-2">
           <a
@@ -303,12 +307,22 @@ function ArtifactCard({ artifact }: { artifact: Artifact }) {
         </div>
       </div>
       {isExpanded && (
-        <iframe
-          src={artifactUrl}
-          className="w-full h-96 border-0"
-          sandbox="allow-scripts"
-          title={artifact.title}
-        />
+        <div className="relative">
+          {isLoading && (
+            <div className="absolute inset-0 flex flex-col items-center justify-center bg-[var(--color-surface-sunken)] h-96">
+              <div className="w-8 h-8 border-2 border-[var(--color-pe-green)] border-t-transparent rounded-full animate-spin mb-3" />
+              <span className="text-sm text-[var(--color-text-muted)]">Building artifact...</span>
+              <span className="text-xs text-[var(--color-text-muted)] mt-1">This may take a moment on first load</span>
+            </div>
+          )}
+          <iframe
+            src={artifactUrl}
+            className={`w-full h-96 border-0 ${isLoading ? "invisible" : ""}`}
+            sandbox="allow-scripts"
+            title={artifact.title}
+            onLoad={() => setIsLoading(false)}
+          />
+        </div>
       )}
     </div>
   );

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -404,6 +404,7 @@ export function ChatInterface({ threadId }: ChatInterfaceProps) {
   const [showShareMenu, setShowShareMenu] = useState(false);
   const [copied, setCopied] = useState(false);
   const [tokenCost, setTokenCost] = useState<number | null>(null);
+  const [model, setModel] = useState<"claude-sonnet-4-5" | "claude-opus-4-5-20251101">("claude-sonnet-4-5");
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const logsEndRef = useRef<HTMLDivElement>(null);
   const supabase = createClient();
@@ -651,6 +652,7 @@ export function ChatInterface({ threadId }: ChatInterfaceProps) {
           question: userMessage,
           history,
           threadId,
+          model,
         }),
       });
 
@@ -700,7 +702,7 @@ export function ChatInterface({ threadId }: ChatInterfaceProps) {
                   setCopied(true);
                   setTimeout(() => setCopied(false), 2000);
                 }}
-                className="flex items-center gap-1.5 px-3 py-1.5 bg-white/20 hover:bg-white/30 rounded-lg text-white text-xs font-medium transition-colors"
+                className="flex items-center gap-1.5 px-3 py-1.5 bg-white/20 hover:bg-white/30 rounded-lg text-white text-xs font-medium transition-colors cursor-pointer"
                 title="Copy entire conversation"
               >
                 <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -713,7 +715,7 @@ export function ChatInterface({ threadId }: ChatInterfaceProps) {
             <div className="relative">
               <button
                 onClick={() => setShowShareMenu(!showShareMenu)}
-                className="flex items-center gap-1.5 px-3 py-1.5 bg-white/20 hover:bg-white/30 rounded-lg text-white text-xs font-medium transition-colors"
+                className="flex items-center gap-1.5 px-3 py-1.5 bg-white/20 hover:bg-white/30 rounded-lg text-white text-xs font-medium transition-colors cursor-pointer"
               >
                 <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />
@@ -726,7 +728,7 @@ export function ChatInterface({ threadId }: ChatInterfaceProps) {
                     <span className="text-sm font-medium text-[var(--color-text-primary)]">Public link</span>
                     <button
                       onClick={togglePublic}
-                      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${isPublic ? "bg-[var(--color-pe-green)]" : "bg-gray-200"}`}
+                      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors cursor-pointer ${isPublic ? "bg-[var(--color-pe-green)]" : "bg-gray-200"}`}
                     >
                       <span className={`inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform ${isPublic ? "translate-x-6" : "translate-x-1"}`} />
                     </button>
@@ -734,7 +736,7 @@ export function ChatInterface({ threadId }: ChatInterfaceProps) {
                   {isPublic && (
                     <button
                       onClick={copyShareLink}
-                      className="w-full flex items-center justify-center gap-2 px-3 py-2 bg-[var(--color-surface-sunken)] hover:bg-[var(--color-border)] rounded-lg text-sm text-[var(--color-text-secondary)] transition-colors"
+                      className="w-full flex items-center justify-center gap-2 px-3 py-2 bg-[var(--color-surface-sunken)] hover:bg-[var(--color-border)] rounded-lg text-sm text-[var(--color-text-secondary)] transition-colors cursor-pointer"
                     >
                       <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
@@ -748,6 +750,15 @@ export function ChatInterface({ threadId }: ChatInterfaceProps) {
                 </div>
               )}
             </div>
+            {/* Model selector */}
+            <select
+              value={model}
+              onChange={(e) => setModel(e.target.value as typeof model)}
+              className="px-2 py-1.5 bg-white/20 hover:bg-white/30 rounded-lg text-white text-xs font-medium transition-colors cursor-pointer border-none outline-none"
+            >
+              <option value="claude-sonnet-4-5" className="text-gray-900">Sonnet 4.5</option>
+              <option value="claude-opus-4-5-20251101" className="text-gray-900">Opus 4.5</option>
+            </select>
             {/* Token cost */}
             {tokenCost !== null && tokenCost > 0 && (
               <div className="flex items-center gap-1.5 px-3 py-1.5 bg-white/20 rounded-lg">
@@ -888,7 +899,7 @@ export function ChatInterface({ threadId }: ChatInterfaceProps) {
           <button
             type="submit"
             disabled={isLoading || !input.trim()}
-            className="px-5 py-3 bg-[var(--color-pe-green)] hover:bg-[var(--color-pe-green-dark)] text-white rounded-xl text-[14px] font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-2 shadow-sm"
+            className="px-5 py-3 bg-[var(--color-pe-green)] hover:bg-[var(--color-pe-green-dark)] text-white rounded-xl text-[14px] font-medium disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer transition-colors flex items-center gap-2 shadow-sm"
           >
             {isLoading ? (
               <>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -108,7 +108,13 @@ export function Sidebar() {
 
   async function deleteThread(id: string, e: React.MouseEvent) {
     e.stopPropagation();
-    await supabase.from("threads").delete().eq("id", id);
+    const { error } = await supabase.from("threads").delete().eq("id", id);
+    if (error) {
+      console.error("Failed to delete thread:", error);
+      return;
+    }
+    // Remove from local state immediately for responsive UI
+    setThreads((prev) => prev.filter((t) => t.id !== id));
     if (currentThreadId === id) {
       router.push("/");
     }
@@ -124,7 +130,7 @@ export function Sidebar() {
       {/* Mobile toggle */}
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="fixed top-4 left-4 z-50 p-2 rounded-lg bg-white border border-[var(--color-border)] md:hidden shadow-sm"
+        className="fixed top-4 left-4 z-50 p-2 rounded-lg bg-white border border-[var(--color-border)] md:hidden shadow-sm cursor-pointer"
       >
         {isOpen ? (
           <svg className="w-5 h-5 text-[var(--color-text-secondary)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -164,7 +170,7 @@ export function Sidebar() {
               disabled={isLoading || !user}
               className="w-full flex items-center justify-center gap-2 px-4 py-2.5
                 bg-[var(--color-pe-green)] hover:bg-[var(--color-pe-green-dark)] text-white rounded-lg
-                transition-colors font-medium text-sm shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                transition-colors font-medium text-sm shadow-sm disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
             >
               {isLoading ? (
                 <>
@@ -236,7 +242,7 @@ export function Sidebar() {
                       <button
                         onClick={(e) => deleteThread(thread.id, e)}
                         className={`
-                          opacity-0 group-hover:opacity-100 p-1.5 rounded-md transition-all
+                          opacity-0 group-hover:opacity-100 p-1.5 rounded-md transition-all cursor-pointer
                           ${
                             currentThreadId === thread.id
                               ? "hover:bg-white/20 text-white/70"

--- a/supabase/migrations/008_artifacts.sql
+++ b/supabase/migrations/008_artifacts.sql
@@ -1,0 +1,25 @@
+-- Artifacts table for storing HTML/JS visualizations
+create table if not exists artifacts (
+  id uuid primary key default gen_random_uuid(),
+  message_id uuid references messages(id) on delete cascade,
+  thread_id uuid references threads(id) on delete cascade,
+  type text not null default 'html',
+  title text,
+  content text not null,
+  dependencies jsonb default '[]'::jsonb,
+  created_at timestamp with time zone default now()
+);
+
+-- RLS policies
+alter table artifacts enable row level security;
+
+create policy "Users can view artifacts in their threads"
+  on artifacts for select
+  using (thread_id in (select id from threads where user_id = auth.uid()));
+
+create policy "Service role can insert artifacts"
+  on artifacts for insert
+  with check (true);
+
+-- Enable realtime
+alter publication supabase_realtime add table artifacts;

--- a/supabase/migrations/009_artifact_dependencies.sql
+++ b/supabase/migrations/009_artifact_dependencies.sql
@@ -1,0 +1,2 @@
+-- Add dependencies column to artifacts table
+alter table artifacts add column if not exists dependencies jsonb default '[]'::jsonb;


### PR DESCRIPTION
Adds general-purpose artifact support with npm dependencies built via bun on Modal.

**Changes:**
- Three artifact types: `html` (static), `react` (React apps), `script` (Node scripts that output HTML)
- New `dependencies` field accepts npm packages to install
- `serve_artifact` endpoint now uses a bun-enabled image to build and run code
- Loading animation in frontend while artifacts compile (can take a moment on cold starts)

The agent can now create rich interactive visualisations with any npm library.